### PR TITLE
fix: hide navbar on register and login pages

### DIFF
--- a/frontend/src/elements/navbar/NavBar.rs
+++ b/frontend/src/elements/navbar/NavBar.rs
@@ -5,6 +5,7 @@ use crate::elements::Sidebar;
 use crate::prelude::*;
 use dioxus::prelude::*;
 use dioxus_router::prelude::*;
+use rustter_endpoint::{CreateUser, Endpoint, Login};
 
 pub fn Init(cx: Scope) -> Element {
     let api_client = ApiClient::global();
@@ -40,17 +41,30 @@ pub fn Init(cx: Scope) -> Element {
 }
 
 pub fn NavBar(cx: Scope) -> Element {
+    let current_route = window().location().pathname().unwrap();
+    // let navigator = use_navigator(cx);
+    let hide_navbar = use_state(cx, || false);
     let new_post_popup_is_hidden = use_state(cx, || true);
     let hide_new_post_popup = move |_| {
         let is_hidden = *new_post_popup_is_hidden.get();
         new_post_popup_is_hidden.set(!is_hidden)
     };
 
+    use_effect(cx, (&current_route,), |(current_route,)| {
+        to_owned![hide_navbar];
+        async move {
+            let should_hide = current_route == Login::URL || current_route == CreateUser::URL;
+            hide_navbar.set(should_hide);
+        }
+    });
+
+    let hide_navbar_class = maybe_class!("hidden", *hide_navbar.get());
+
     cx.render(rsx! {
         Init {},
         Sidebar {},
         nav {
-            class: "max-w-[var(--content-max-width)] h-[var(--navbar-height)] fixed bottom-0 left-0 right-0 mx-auto border-t navbar-bg-color navbar-border-color",
+            class: "max-w-[var(--content-max-width)] h-[var(--navbar-height)] fixed bottom-0 left-0 right-0 mx-auto border-t navbar-bg-color navbar-border-color {hide_navbar_class}",
             div {
                 class: "grid grid-cols-3 justify-around w-full h-full items-center shadow-inner",
                 NavButton {


### PR DESCRIPTION
- intro-setup
- fe-register
- fe-register-add-route
- fe-register-form
- fe-state-hooks
- fe-username-input
- fe-username-input-handler
- fe-password-input
- domain-types
- dt-username-password
- fe-keyed-notif
- fe-keyed-notif-box
- fe-notif-integration
- fe-disable-submit
- api-server-state
- api-binary
- api-binary-run
- api-binary-run-fix
- api-binary-run-2
- api-create-router
- api-env
- db-user-id
- db-overview
- api-route-layer
- endpoint-crate
- api-errors
- api-db-extract
- api-public-request
- handler-create-user
- fe-create-user
- friendly-errors
- fe-login-page
- db-ids
- db-session
- db-session-query
- api-user-login
- api-user-session
- fe-login
- fe-home-route
- api-login-new-user
- fe-navbar
- fe-navbar-button
- fe-navbar-post
- post-data
- post-content
- authorized-requests
- auth-handler
- db-new-post
- new-post-handler
- url-macro
- fe-new-chat
- nc-message
- nc-headline
- nc-fetch
- nc-check
- fe-toaster
- fe-toaster-template
- fe-toaster-cleanup
- nc-toast
- post-types
- trending-endpoint
- public-post-1
- public-post-2
- fe-trending-page
- post-manager
- populate-posts
- render-content
- render-header
- ab-template
- ab-bookmark
- ab-bookmark-db
- ab-bookmark-status
- ab-reaction-query
- ab-reaction-endpoint
- ab-reaction-button
- ab-reaction-template
- ab-aggregate-reaction
- ab-like-status
- ab-boost-query
- ab-boost-endpoint
- ab-boost-button
- restart-server
- ab-quick-respond
- ab-qr-input
- ab-qr-check
- img-ops
- img-url-map
- img-endpoint
- img-handler
- fe-post-image-template
- fe-post-image-upload
- fe-post-image-preview
- img-payload-size
- fe-post-image-display
- poll-endpoint
- poll-query
- poll-query-2
- poll-to-public
- fe-new-poll
- fe-poll-choices
- fe-poll-route
- fe-poll-display
- fe-poll-display-2
- vote-endpoint
- vote-handler
- bar-layout
- bar-buttons
- bar-new-post
- bar-new-post-2
- home-query-main
- home-query-2
- home-endpoints
- fe-home
- fe-home-2
- pm-endpoint
- pm-query-update
- pm-handler
- pm-handler-update
- pm-fe-update
- pm-fe-img
- mp-fe-email
- pm-fe-email-field
- pm-fe-display-name
- pm-fe-password
- pm-fe-submit
- pm-fe-on-submit
- pm-fe-check-submit
- pm-fe-appbar
- vp-endpoint
- vp-fe-route
- vp-fe-fetch
- vp-fe-template
- vp-post
- vp-check
- vp-profile-image
- vp-folllow-backend
- vp-follow-fetch
- local-profile
- local-profile-populate
- sb-init
- sb-overlay
- sb-buttons
- sb-profile-image
- empty-home
- fe-trend-fix
- data-url-fix
- follower-fix
- login-swap
- hide-nav
