### PR TITLE
fix: display messages if no bookmarked/liked posts yet

### DIFF
--- a/frontend/src/page/posts/bookmarked.rs
+++ b/frontend/src/page/posts/bookmarked.rs
@@ -1,8 +1,10 @@
 use crate::prelude::*;
 use dioxus::prelude::*;
+use dioxus_router::hooks::use_navigator;
 use log::info;
 
 pub fn BookmarkedPosts(cx: Scope) -> Element {
+    let nav = use_navigator(cx);
     let toaster = use_toaster(cx);
     let api_client = ApiClient::global();
     let post_manager = use_post_manager(cx);
@@ -31,7 +33,32 @@ pub fn BookmarkedPosts(cx: Scope) -> Element {
         });
     }
 
-    let Posts = post_manager.read().all_to_public();
+    let Posts = {
+        let posts = post_manager.read().all_to_public();
+
+        if posts.is_empty() {
+            let TrendingLink = rsx! {
+                a {
+                    class: "link",
+                    onclick: move|_| {
+                        nav.push(Route::TrendingPosts {});
+                    },
+                    "trending,"
+                }
+            };
+
+            rsx! {
+                div {
+                    class: "flex flex-col text-center justify-center h-[calc(100vh_-_var(--navbar-height)_-_var(--appbar-height))]",
+                    span {
+                        "You don't have any bookmarked posts yet. Check out what's " TrendingLink " and follow some users to get started."
+                    }
+                }
+            }
+        } else {
+            rsx! { posts.into_iter() }
+        }
+    };
 
     render! {
         AppBar {title: "Bookmarks", buttons: vec![
@@ -57,7 +84,7 @@ pub fn BookmarkedPosts(cx: Scope) -> Element {
             }
         div {
          class:"overflow-y-auto max-h-[calc(100vh-var(--navbar-height))]",
-            Posts.into_iter()
+            Posts
         }
     }
 }

--- a/frontend/src/page/posts/bookmarked.rs
+++ b/frontend/src/page/posts/bookmarked.rs
@@ -16,6 +16,8 @@ pub fn BookmarkedPosts(cx: Scope) -> Element {
             use rustter_endpoint::post::endpoint::{BookmarkedPosts, BookmarkedPostsOk};
             toaster.write().info("Fetching bookmarked posts", None);
 
+            post_manager.write().clear();
+
             let response = fetch_json!(<BookmarkedPostsOk>, api_client, BookmarkedPosts);
             match response {
                 Ok(res) => post_manager.write().populate(res.0.into_iter()),

--- a/frontend/src/page/posts/liked.rs
+++ b/frontend/src/page/posts/liked.rs
@@ -1,8 +1,10 @@
 use crate::prelude::*;
 use dioxus::prelude::*;
+use dioxus_router::hooks::use_navigator;
 use log::info;
 
 pub fn LikedPosts(cx: Scope) -> Element {
+    let nav = use_navigator(cx);
     let toaster = use_toaster(cx);
     let api_client = ApiClient::global();
     let post_manager = use_post_manager(cx);
@@ -31,7 +33,33 @@ pub fn LikedPosts(cx: Scope) -> Element {
         });
     }
 
-    let Posts = post_manager.read().all_to_public();
+    // FIXME: duplicate (home and bookmarks page), refactor
+    let Posts = {
+        let posts = post_manager.read().all_to_public();
+
+        if posts.is_empty() {
+            let TrendingLink = rsx! {
+                a {
+                    class: "link",
+                    onclick: move|_| {
+                        nav.push(Route::TrendingPosts {});
+                    },
+                    "trending,"
+                }
+            };
+
+            rsx! {
+                div {
+                    class: "flex flex-col text-center justify-center h-[calc(100vh_-_var(--navbar-height)_-_var(--appbar-height))]",
+                    span {
+                        "You don't have any liked posts yet. Check out what's " TrendingLink " and follow some users to get started."
+                    }
+                }
+            }
+        } else {
+            rsx! { posts.into_iter() }
+        }
+    };
 
     render! {
         AppBar {title: "Liked", buttons: vec![
@@ -57,7 +85,7 @@ pub fn LikedPosts(cx: Scope) -> Element {
             }
         div {
          class:"overflow-y-auto max-h-[calc(100vh-var(--navbar-height))]",
-            Posts.into_iter()
+            Posts
         }
     }
 }

--- a/frontend/src/page/posts/liked.rs
+++ b/frontend/src/page/posts/liked.rs
@@ -16,6 +16,8 @@ pub fn LikedPosts(cx: Scope) -> Element {
             use rustter_endpoint::post::endpoint::{LikedPosts, LikedPostsOk};
             toaster.write().info("Fetching liked posts", None);
 
+            post_manager.write().clear();
+
             let response = fetch_json!(<LikedPostsOk>, api_client, LikedPosts);
             match response {
                 Ok(res) => post_manager.write().populate(res.0.into_iter()),


### PR DESCRIPTION
- intro-setup
- fe-register
- fe-register-add-route
- fe-register-form
- fe-state-hooks
- fe-username-input
- fe-username-input-handler
- fe-password-input
- domain-types
- dt-username-password
- fe-keyed-notif
- fe-keyed-notif-box
- fe-notif-integration
- fe-disable-submit
- api-server-state
- api-binary
- api-binary-run
- api-binary-run-fix
- api-binary-run-2
- api-create-router
- api-env
- db-user-id
- db-overview
- api-route-layer
- endpoint-crate
- api-errors
- api-db-extract
- api-public-request
- handler-create-user
- fe-create-user
- friendly-errors
- fe-login-page
- db-ids
- db-session
- db-session-query
- api-user-login
- api-user-session
- fe-login
- fe-home-route
- api-login-new-user
- fe-navbar
- fe-navbar-button
- fe-navbar-post
- post-data
- post-content
- authorized-requests
- auth-handler
- db-new-post
- new-post-handler
- url-macro
- fe-new-chat
- nc-message
- nc-headline
- nc-fetch
- nc-check
- fe-toaster
- fe-toaster-template
- fe-toaster-cleanup
- nc-toast
- post-types
- trending-endpoint
- public-post-1
- public-post-2
- fe-trending-page
- post-manager
- populate-posts
- render-content
- render-header
- ab-template
- ab-bookmark
- ab-bookmark-db
- ab-bookmark-status
- ab-reaction-query
- ab-reaction-endpoint
- ab-reaction-button
- ab-reaction-template
- ab-aggregate-reaction
- ab-like-status
- ab-boost-query
- ab-boost-endpoint
- ab-boost-button
- restart-server
- ab-quick-respond
- ab-qr-input
- ab-qr-check
- img-ops
- img-url-map
- img-endpoint
- img-handler
- fe-post-image-template
- fe-post-image-upload
- fe-post-image-preview
- img-payload-size
- fe-post-image-display
- poll-endpoint
- poll-query
- poll-query-2
- poll-to-public
- fe-new-poll
- fe-poll-choices
- fe-poll-route
- fe-poll-display
- fe-poll-display-2
- vote-endpoint
- vote-handler
- bar-layout
- bar-buttons
- bar-new-post
- bar-new-post-2
- home-query-main
- home-query-2
- home-endpoints
- fe-home
- fe-home-2
- pm-endpoint
- pm-query-update
- pm-handler
- pm-handler-update
- pm-fe-update
- pm-fe-img
- mp-fe-email
- pm-fe-email-field
- pm-fe-display-name
- pm-fe-password
- pm-fe-submit
- pm-fe-on-submit
- pm-fe-check-submit
- pm-fe-appbar
- vp-endpoint
- vp-fe-route
- vp-fe-fetch
- vp-fe-template
- vp-post
- vp-check
- vp-profile-image
- vp-folllow-backend
- vp-follow-fetch
- local-profile
- local-profile-populate
- sb-init
- sb-overlay
- sb-buttons
- sb-profile-image
- empty-home
- fe-trend-fix
- data-url-fix
- follower-fix
- login-swap
- hide-nav
- login-profile-image
- no-blank-pages
